### PR TITLE
docs: fix typo in TODO comment (diretory→directory)

### DIFF
--- a/src/main/java/com/l3harris/swim/outputs/MessageFileOutput.java
+++ b/src/main/java/com/l3harris/swim/outputs/MessageFileOutput.java
@@ -18,7 +18,7 @@ public class MessageFileOutput extends Output {
 
     public MessageFileOutput(Config config) {
         super(config);
-        // TODO change the diretory from config
+        // TODO change the directory from config
         outputDirectory = new File("./log/");
     }
 


### PR DESCRIPTION
## Summary

Fix spelling error in `MessageFileOutput.java`:

- "diretory" → "directory" (TODO comment)

No functional changes — comment only.